### PR TITLE
Add more configuration options for the lobby

### DIFF
--- a/src/main/java/dev/ftb/mods/ftbteamdimensions/FTBDimensionsConfig.java
+++ b/src/main/java/dev/ftb/mods/ftbteamdimensions/FTBDimensionsConfig.java
@@ -1,6 +1,7 @@
 package dev.ftb.mods.ftbteamdimensions;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.GameType;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.ModConfig;
@@ -36,6 +37,9 @@ public class FTBDimensionsConfig {
         public final ForgeConfigSpec.BooleanValue teamSpecificNetherEntryPoint;
         public final ForgeConfigSpec.BooleanValue placeEntitiesInStartStructure;
         public final ForgeConfigSpec.IntValue replaceColdBiomesNearSpawn;
+        public final ForgeConfigSpec.EnumValue<GameType> lobbyGameMode;
+        public final ForgeConfigSpec.BooleanValue allowLobbyDamages;
+
 
         public CategoryCommonGeneral() {
             COMMON_BUILDER.push("general");
@@ -79,6 +83,14 @@ public class FTBDimensionsConfig {
             this.replaceColdBiomesNearSpawn = COMMON_BUILDER
                     .comment("If > 0, any chunk closer than this to spawn with a cold biome (i.e. water can freeze) in its X/Z midpoint will have its biome replaced with 'minecraft:plains'. Set to 0 to disable all replacement.")
                     .defineInRange("replaceColdBiomesNearSpawn", 64, 0, Integer.MAX_VALUE);
+
+            this.lobbyGameMode = COMMON_BUILDER
+                    .comment("Define the gamemode attributed to players when in the lobby")
+                    .defineEnum("lobbyGameMode", GameType.ADVENTURE);
+
+            this.allowLobbyDamages = COMMON_BUILDER
+                    .comment("If true, living entities can deal damages in the lobby")
+                            .define("allowLobbyDamages", false);
 
             COMMON_BUILDER.pop();
         }

--- a/src/main/java/dev/ftb/mods/ftbteamdimensions/dimensions/DimensionsMain.java
+++ b/src/main/java/dev/ftb/mods/ftbteamdimensions/dimensions/DimensionsMain.java
@@ -91,6 +91,10 @@ public class DimensionsMain {
 
     @SubscribeEvent
     public static void onPlayerDamage(LivingDamageEvent event) {
+        if (FTBDimensionsConfig.COMMON_GENERAL.allowLobbyDamages.get()) {
+            return;
+        }
+
         if (event.getEntity().level.dimension().equals(Level.OVERWORLD) && event.getSource() != DamageSource.OUT_OF_WORLD) {
             event.setCanceled(true);
         }
@@ -192,18 +196,19 @@ public class DimensionsMain {
     }
 
     /**
-     * When entering the overworld (lobby) the player will be switch to Adventure mode as long as they're not in creative mode,
-     * upon the overworld whilst the game mode is set to adventure, we'll switch back to survival
+     * When entering the overworld (lobby) the player will be switched to the lobby game mode as long as they're not in creative mode,
+     * upon the overworld whilst the game mode is set to the lobby game mode, we'll switch back to survival
      *
      * @param dimension dimension entering from or leaving
      * @param player    the player leaving or entering a dimension.
      */
     private static void swapGameMode(ResourceKey<Level> dimension, ServerPlayer player) {
-        if (dimension.location().equals(OVERWORLD) && player.gameMode.getGameModeForPlayer() != GameType.ADVENTURE && player.gameMode.getGameModeForPlayer() != GameType.CREATIVE) {
-            player.setGameMode(GameType.ADVENTURE);
+        GameType lobbyGameMode = FTBDimensionsConfig.COMMON_GENERAL.lobbyGameMode.get();
+        if (dimension.location().equals(OVERWORLD) && player.gameMode.getGameModeForPlayer() != lobbyGameMode && player.gameMode.getGameModeForPlayer() != GameType.CREATIVE) {
+            player.setGameMode(lobbyGameMode);
         }
 
-        if (!dimension.location().equals(OVERWORLD) && player.gameMode.getGameModeForPlayer() == GameType.ADVENTURE) {
+        if (!dimension.location().equals(OVERWORLD) && player.gameMode.getGameModeForPlayer() == lobbyGameMode) {
             player.setGameMode(GameType.SURVIVAL);
         }
     }


### PR DESCRIPTION
In our sever the lobby is shared and we would like the players to be able to build there
So i made some modifcations that will allow us to have that behaviour while keeping the original behaviour of the lobby as default.

i added in the config two more options

1.  Be able to set the game mode of the player in the lobby to sometihg else than Adventure
2. Allow players to take damage in the lobby if enabled

This code has been tested on our server for a few days now and works alright ^^